### PR TITLE
hotfix: User-Agent header to replace the current one (requests default)

### DIFF
--- a/justetf_scraping/overview.py
+++ b/justetf_scraping/overview.py
@@ -246,6 +246,7 @@ def get_raw_overview(
     strategies = list(STRATEGIES) if strategy is None else [strategy]
     rows: List[Dict[str, Any]] = []
     with requests.Session() as session:
+        session.headers.update({'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36'})
         html_response = session.get(f"{BASE_URL}?search=ETFS")
         if match := PATTERN.search(html_response.text):
             counter = int(match.group(1))


### PR DESCRIPTION
Hello,

Currently, using the default User-Agent header from the Python requests package is resulting in a 403 status code for all calls.
It seems they are blocking certain bot User-Agents, such as `curl` or `requests`.

@druzsan, could you please review and merge this pull request to resolve the issue?

Thank you!