### PR TITLE
etf_profile.py: align XML parsing to AJAX response

### DIFF
--- a/justetf_scraping/etf_profile.py
+++ b/justetf_scraping/etf_profile.py
@@ -151,7 +151,7 @@ def _parse_allocation_from_ajax(
 
     Args:
         xml_response: XML response from AJAX call
-        table_id: ID of the table element (e.g., 'id47')
+        table_id: ID of the table element (e.g., 'id47', or '*' to include all table elements)
         name_testid: data-testid for name element
         pct_testid: data-testid for percentage element
 
@@ -164,7 +164,7 @@ def _parse_allocation_from_ajax(
         # Parse XML and extract CDATA content for the table
         root = ElementTree.fromstring(xml_response)
         for component in root.findall(".//component"):
-            if component.get("id") == table_id:
+            if table_id in [component.get("id"), "*"]:
                 html_content = component.text
                 if html_content:
                     soup = BeautifulSoup(html_content, "html.parser")
@@ -179,7 +179,8 @@ def _parse_allocation_from_ajax(
                                 allocations.append(
                                     AllocationItem(name=name, percentage=pct)
                                 )
-                break
+                if table_id != "*":
+                    break
     except Exception as e:
         print(f"Error parsing allocation data: {e}")
 
@@ -295,7 +296,7 @@ def get_etf_overview(
         if countries_xml:
             countries = _parse_allocation_from_ajax(
                 countries_xml,
-                "id47",
+                "id46",
                 "tl_etf-holdings_countries_value_name",
                 "tl_etf-holdings_countries_value_percentage",
             )
@@ -323,7 +324,7 @@ def get_etf_overview(
         if sectors_xml:
             sectors = _parse_allocation_from_ajax(
                 sectors_xml,
-                "id48",
+                "id47",
                 "tl_etf-holdings_sectors_value_name",
                 "tl_etf-holdings_sectors_value_percentage",
             )


### PR DESCRIPTION
Existing code did not correctly extract countries and sectors from AJAX responses, e.g. in below call the returned lists are empty.

    get_etf_overview("IE00BK5BQT80", include_gettex=False)

Root cause may be that the AJAX response XML has slightly changed: for countries, the XML reads:
    ...</component><component id="id46" ><![CDATA[<ta....
for sectors, the XML reads:
    ...</component><component id="id47" ><![CDATA[<ta...
Thus, the numbering of 'id' seems to have evolved to decrement-by-one.

Proposed fix:

1. just corrects id47->id46 and id48->id47.

2. extends '_parse_allocation_from_ajax' with looser table_id handling, yet does not use that functionality yet. In case the user of this function passes table_id='*', the code behaves wild-card like and extracts info from any component-id. It was tested that following code e.g. works:

        if countries_xml:
            countries = _parse_allocation_from_ajax(
                countries_xml,
                "*",
                "tl_etf-holdings_countries_value_name",
                "tl_etf-holdings_countries_value_percentage",
            )

   If at some moment in time the numbering of AJAX table-id's proves too volatile, it can be opted to use the wildcard approach. The AJAX XML snippet already seems very limited to only contain country- or sector-information, there is (at this moment) little other information which could invalidly be dragged along.