### PR TITLE
fix(etf_profile): fix NameError and broken AJAX allocation parsing

### DIFF
--- a/justetf_scraping/etf_profile.py
+++ b/justetf_scraping/etf_profile.py
@@ -13,6 +13,7 @@ from xml.etree import ElementTree
 import requests
 from bs4 import BeautifulSoup
 
+from .live_quote import load_live_quote
 from .types import Quote
 
 
@@ -144,14 +145,14 @@ def _fetch_ajax_data(
 
 
 def _parse_allocation_from_ajax(
-    xml_response: str, table_id: str, name_testid: str, pct_testid: str
+    xml_response: str, table_testid: str, name_testid: str, pct_testid: str
 ) -> List[AllocationItem]:
     """
     Parse allocation data (countries/sectors) from AJAX XML response.
 
     Args:
         xml_response: XML response from AJAX call
-        table_id: ID of the table element (e.g., 'id47')
+        table_testid: data-testid of the table element (e.g., 'etf-holdings_countries_table')
         name_testid: data-testid for name element
         pct_testid: data-testid for percentage element
 
@@ -164,22 +165,25 @@ def _parse_allocation_from_ajax(
         # Parse XML and extract CDATA content for the table
         root = ElementTree.fromstring(xml_response)
         for component in root.findall(".//component"):
-            if component.get("id") == table_id:
-                html_content = component.text
-                if html_content:
-                    soup = BeautifulSoup(html_content, "html.parser")
-                    rows = soup.find_all("tr", attrs={"data-testid": True})
-                    for row in rows:
-                        name_elem = row.find("td", attrs={"data-testid": name_testid})
-                        pct_elem = row.find("span", attrs={"data-testid": pct_testid})
-                        if name_elem and pct_elem:
-                            name = name_elem.get_text(strip=True)
-                            pct = _parse_percentage(pct_elem.get_text(strip=True))
-                            if name and pct is not None:
-                                allocations.append(
-                                    AllocationItem(name=name, percentage=pct)
-                                )
-                break
+            html_content = component.text
+            if not html_content:
+                continue
+            # Match on stable data-testid instead of dynamic Wicket element ID
+            if f'data-testid="{table_testid}"' not in html_content:
+                continue
+            soup = BeautifulSoup(html_content, "html.parser")
+            rows = soup.find_all("tr", attrs={"data-testid": True})
+            for row in rows:
+                name_elem = row.find("td", attrs={"data-testid": name_testid})
+                pct_elem = row.find("span", attrs={"data-testid": pct_testid})
+                if name_elem and pct_elem:
+                    name = name_elem.get_text(strip=True)
+                    pct = _parse_percentage(pct_elem.get_text(strip=True))
+                    if name and pct is not None:
+                        allocations.append(
+                            AllocationItem(name=name, percentage=pct)
+                        )
+            break
     except Exception as e:
         print(f"Error parsing allocation data: {e}")
 
@@ -295,7 +299,7 @@ def get_etf_overview(
         if countries_xml:
             countries = _parse_allocation_from_ajax(
                 countries_xml,
-                "id47",
+                "etf-holdings_countries_table",
                 "tl_etf-holdings_countries_value_name",
                 "tl_etf-holdings_countries_value_percentage",
             )
@@ -323,7 +327,7 @@ def get_etf_overview(
         if sectors_xml:
             sectors = _parse_allocation_from_ajax(
                 sectors_xml,
-                "id48",
+                "etf-holdings_sectors_table",
                 "tl_etf-holdings_sectors_value_name",
                 "tl_etf-holdings_sectors_value_percentage",
             )
@@ -353,7 +357,7 @@ def get_etf_overview(
     # Get gettex quote
     gettex = None
     if include_gettex:
-        gettex = get_gettex_quote(isin)
+        gettex = load_live_quote(isin)
 
     # Build result
     return EtfOverview(

--- a/tests/test_etf_profile.py
+++ b/tests/test_etf_profile.py
@@ -1,0 +1,192 @@
+"""
+Tests for `justetf_scraping.etf_profile` module.
+"""
+
+from unittest.mock import patch
+
+from justetf_scraping.etf_profile import (
+    _parse_allocation_from_ajax,
+    _parse_percentage,
+    get_etf_overview,
+)
+
+# --- Test helpers ---
+
+
+def test_parse_percentage_valid() -> None:
+    """Test parsing valid percentage strings."""
+    assert _parse_percentage("59.03%") == 59.03
+    assert _parse_percentage("0.19% p.a.") == 0.19
+    assert _parse_percentage("100%") == 100.0
+
+
+def test_parse_percentage_invalid() -> None:
+    """Test parsing invalid or empty percentage strings."""
+    assert _parse_percentage("") is None
+    assert _parse_percentage("no percent here") is None
+
+
+# --- Bug 1: get_gettex_quote NameError ---
+
+
+def test_include_gettex_uses_load_live_quote() -> None:
+    """Test that include_gettex=True calls load_live_quote, not get_gettex_quote."""
+    # Mock the session/request to avoid real HTTP calls
+    mock_quote = object()
+
+    with (
+        patch("justetf_scraping.etf_profile.requests.Session") as mock_session_cls,
+        patch("justetf_scraping.etf_profile.load_live_quote", return_value=mock_quote) as mock_llq,
+    ):
+        mock_session = mock_session_cls.return_value
+        # Return a minimal valid HTML page
+        mock_response = mock_session.get.return_value
+        mock_response.status_code = 200
+        mock_response.text = "<html><head><title>Test ETF | WKN | IE00TEST</title></head><body></body></html>"
+
+        result = get_etf_overview("IE00TEST", include_gettex=True, expand_allocations=False)
+
+        mock_llq.assert_called_once_with("IE00TEST")
+        assert result["gettex"] is mock_quote
+
+
+def test_include_gettex_false_skips_quote() -> None:
+    """Test that include_gettex=False does not call load_live_quote."""
+    with (
+        patch("justetf_scraping.etf_profile.requests.Session") as mock_session_cls,
+        patch("justetf_scraping.etf_profile.load_live_quote") as mock_llq,
+    ):
+        mock_session = mock_session_cls.return_value
+        mock_response = mock_session.get.return_value
+        mock_response.status_code = 200
+        mock_response.text = "<html><head><title>Test ETF | WKN | IE00TEST</title></head><body></body></html>"
+
+        result = get_etf_overview("IE00TEST", include_gettex=False, expand_allocations=False)
+
+        mock_llq.assert_not_called()
+        assert result["gettex"] is None
+
+
+# --- Bug 2: AJAX allocation parsing with dynamic Wicket IDs ---
+
+# Simulate a real AJAX XML response with a dynamic element ID (id46 instead of id47)
+COUNTRIES_AJAX_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<ajax-response>
+<component id="id46" encoding="wicket1"><![CDATA[
+<table data-testid="etf-holdings_countries_table">
+<tr data-testid="etf-holdings_countries_row">
+  <td data-testid="tl_etf-holdings_countries_value_name">United States</td>
+  <td><span data-testid="tl_etf-holdings_countries_value_percentage">59.03%</span></td>
+</tr>
+<tr data-testid="etf-holdings_countries_row">
+  <td data-testid="tl_etf-holdings_countries_value_name">Japan</td>
+  <td><span data-testid="tl_etf-holdings_countries_value_percentage">6.12%</span></td>
+</tr>
+<tr data-testid="etf-holdings_countries_row">
+  <td data-testid="tl_etf-holdings_countries_value_name">United Kingdom</td>
+  <td><span data-testid="tl_etf-holdings_countries_value_percentage">3.85%</span></td>
+</tr>
+</table>
+]]></component>
+</ajax-response>"""
+
+SECTORS_AJAX_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<ajax-response>
+<component id="id99" encoding="wicket1"><![CDATA[
+<table data-testid="etf-holdings_sectors_table">
+<tr data-testid="etf-holdings_sectors_row">
+  <td data-testid="tl_etf-holdings_sectors_value_name">Technology</td>
+  <td><span data-testid="tl_etf-holdings_sectors_value_percentage">23.45%</span></td>
+</tr>
+<tr data-testid="etf-holdings_sectors_row">
+  <td data-testid="tl_etf-holdings_sectors_value_name">Financials</td>
+  <td><span data-testid="tl_etf-holdings_sectors_value_percentage">15.67%</span></td>
+</tr>
+</table>
+]]></component>
+</ajax-response>"""
+
+
+def test_parse_countries_from_ajax_with_dynamic_id() -> None:
+    """Test that AJAX parsing works regardless of the Wicket element ID."""
+    countries = _parse_allocation_from_ajax(
+        COUNTRIES_AJAX_XML,
+        "etf-holdings_countries_table",
+        "tl_etf-holdings_countries_value_name",
+        "tl_etf-holdings_countries_value_percentage",
+    )
+
+    assert len(countries) == 3
+    assert countries[0]["name"] == "United States"
+    assert countries[0]["percentage"] == 59.03
+    assert countries[1]["name"] == "Japan"
+    assert countries[1]["percentage"] == 6.12
+    assert countries[2]["name"] == "United Kingdom"
+    assert countries[2]["percentage"] == 3.85
+
+
+def test_parse_sectors_from_ajax_with_dynamic_id() -> None:
+    """Test that sector AJAX parsing works regardless of the Wicket element ID."""
+    sectors = _parse_allocation_from_ajax(
+        SECTORS_AJAX_XML,
+        "etf-holdings_sectors_table",
+        "tl_etf-holdings_sectors_value_name",
+        "tl_etf-holdings_sectors_value_percentage",
+    )
+
+    assert len(sectors) == 2
+    assert sectors[0]["name"] == "Technology"
+    assert sectors[0]["percentage"] == 23.45
+    assert sectors[1]["name"] == "Financials"
+    assert sectors[1]["percentage"] == 15.67
+
+
+def test_parse_ajax_no_matching_testid() -> None:
+    """Test that AJAX parsing returns empty list when no matching data-testid is found."""
+    result = _parse_allocation_from_ajax(
+        COUNTRIES_AJAX_XML,
+        "etf-holdings_nonexistent_table",
+        "tl_etf-holdings_countries_value_name",
+        "tl_etf-holdings_countries_value_percentage",
+    )
+    assert result == []
+
+
+def test_parse_ajax_multiple_components() -> None:
+    """Test AJAX parsing when response contains multiple components."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<ajax-response>
+<component id="id10" encoding="wicket1"><![CDATA[
+<div>Some other content</div>
+]]></component>
+<component id="id20" encoding="wicket1"><![CDATA[
+<table data-testid="etf-holdings_countries_table">
+<tr data-testid="row">
+  <td data-testid="tl_etf-holdings_countries_value_name">France</td>
+  <td><span data-testid="tl_etf-holdings_countries_value_percentage">2.50%</span></td>
+</tr>
+</table>
+]]></component>
+</ajax-response>"""
+
+    countries = _parse_allocation_from_ajax(
+        xml,
+        "etf-holdings_countries_table",
+        "tl_etf-holdings_countries_value_name",
+        "tl_etf-holdings_countries_value_percentage",
+    )
+
+    assert len(countries) == 1
+    assert countries[0]["name"] == "France"
+    assert countries[0]["percentage"] == 2.50
+
+
+def test_parse_ajax_invalid_xml() -> None:
+    """Test that AJAX parsing handles invalid XML gracefully."""
+    result = _parse_allocation_from_ajax(
+        "this is not xml",
+        "etf-holdings_countries_table",
+        "tl_etf-holdings_countries_value_name",
+        "tl_etf-holdings_countries_value_percentage",
+    )
+    assert result == []


### PR DESCRIPTION
Fixes #28 (country/sector allocations)

## Summary

- **Bug 1:** `get_etf_overview(include_gettex=True)` raises `NameError: name 'get_gettex_quote' is not defined` — replaced with `load_live_quote()` from the `live_quote` module.
- **Bug 2:** `_parse_allocation_from_ajax()` always returns empty lists for countries/sectors because it matches on hardcoded Wicket element IDs (`id47`/`id48`) which are dynamic. Replaced with stable `data-testid` attributes (`etf-holdings_countries_table`, `etf-holdings_sectors_table`).

## Details

### Bug 1: NameError on `get_gettex_quote`

`get_etf_overview()` calls `get_gettex_quote(isin)` at line 356, but this function is never defined or imported. It was clearly intended to call `load_live_quote` from `live_quote.py`.

### Bug 2: AJAX allocation parsing broken by dynamic Wicket IDs

The AJAX XML response contains `<component>` elements with Wicket-generated IDs like `id46`, `id47`, etc. These IDs are **dynamic** — they change between pages and sessions. The code hardcoded `id47` for countries and `id48` for sectors, which never match the actual response.

**Verified against live justETF AJAX responses** for two different ETFs (`IE00BK5BQT80` and `IE00B4L5Y983`):
- The countries table component has `id="id46"` (not `id47` as hardcoded)
- The `data-testid="etf-holdings_countries_table"` is stable across both ETFs
- Same pattern for sectors

The fix matches on `data-testid` in the CDATA content instead of the dynamic `id` attribute on the `<component>` element. This is the same approach suggested by @marcussteinbacher in #28.

### Comparison with #34

PR #34 fixes the same Bug 2 but by swapping one hardcoded ID for another (`id47`→`id46`), which will break again if Wicket changes IDs. This PR uses `data-testid` which is a stable application-level attribute.

## Test plan

- [x] Added 9 unit tests in `tests/test_etf_profile.py` covering both bugs
- [x] All 17 tests pass (including existing chart and live_quote tests)
- [x] Verified fix against live justETF responses for multiple ISINs

🤖 Generated with [Claude Code](https://claude.com/claude-code)