### PR TITLE
Fix parsing UTC live quote timestamps

### DIFF
--- a/justetf_scraping/types.py
+++ b/justetf_scraping/types.py
@@ -117,6 +117,15 @@ def parse_quote_trend(raw_quote_trend: RawQuoteTrend) -> QuoteTrend | None:
     return None
 
 
+def parse_timestamp(timestamp: str) -> datetime.datetime:
+    """
+    Parse a quote timestamp.
+    """
+    if timestamp.endswith("Z"):
+        timestamp = f"{timestamp[:-1]}+00:00"
+    return datetime.datetime.fromisoformat(timestamp)
+
+
 @dataclasses.dataclass
 class Quote:
     """
@@ -166,7 +175,7 @@ def parse_quote(raw_quote: RawQuote) -> Quote:
     """
     return Quote(
         isin=raw_quote["isin"],
-        timestamp=datetime.datetime.fromisoformat(raw_quote["timestamp"]),
+        timestamp=parse_timestamp(raw_quote["timestamp"]),
         exchange=raw_quote["stockExchange"],
         currency=raw_quote["currency"],
         trend=parse_quote_trend(raw_quote["trend"]),

--- a/tests/test_live_quote.py
+++ b/tests/test_live_quote.py
@@ -2,6 +2,7 @@
 Tests for `justetf_scraping.live_quote` module.
 """
 
+import datetime
 from typing import Iterator
 
 import pytest
@@ -98,6 +99,9 @@ def test_load_initial_live_quote(monkeypatch: pytest.MonkeyPatch) -> None:
 
     quote = justetf_scraping.live_quote.load_live_quote("initial")
     assert quote.trend is None
+    assert quote.timestamp == datetime.datetime(
+        2026, 1, 30, tzinfo=datetime.timezone.utc
+    )
 
 
 def test_load_down_live_quote(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- parse live quote timestamps with a `Z` UTC suffix on Python 3.10
- normalize trailing `Z` to `+00:00` before `datetime.fromisoformat()`
- assert the parsed live quote timestamp keeps UTC timezone information

Closes #50

## Tests
- `uv run --python 3.10 pytest tests/test_live_quote.py -q`
- `uv run --python 3.10 pytest -q`
- `uv run --python 3.10 ruff format --target-version py310 --check`
- `uv run --python 3.10 ruff check --target-version py310`
- `uv run --python 3.10 ty check --error-on-warning justetf_scraping/types.py`

## Notes
- The full `uv run --python 3.10 ty check --error-on-warning` still reports pre-existing diagnostics in `etf_profile.py` and notebooks, plus missing optional notebook dependencies. The touched `justetf_scraping/types.py` file passes `ty` directly.

AI assistance was used under my direction.